### PR TITLE
Add dependencies to `setup.py` so they're installed automatically with `pip install .`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,16 @@ setup(
 			"vtandem = vtandem.vtandem:vtandem"
 		]
 	},
+	install_requires=[
+		"numpy>=1.16",
+		"matplotlib>=3.0",
+		"matplotlib-label-lines",
+		"pymatgen",
+		"periodictable",
+		"PyQt5",
+		"click>8.0",
+	],
+	dependency_links=['https://github.com/frssp/PyPolyhedron/master#egg=polyhedron-0.2.1'],
 )
 
 

--- a/setup.py
+++ b/setup.py
@@ -45,8 +45,8 @@ setup(
 		"periodictable",
 		"PyQt5",
 		"click>8.0",
+		"polyhedron @ https://github.com/frssp/PyPolyhedron/archive/master.zip#egg=polyhedron-0.2.1",
 	],
-	dependency_links=['https://github.com/frssp/PyPolyhedron/master#egg=polyhedron-0.2.1'],
 )
 
 


### PR DESCRIPTION
Just a convenience addition so cloning and then doing `pip install .` installs all required dependencies. 
Tested and works as expected on my local and HPC